### PR TITLE
Change git info commit time to a string instead of longs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 
-version = '0.9.83'
+version = '0.9.84'
 group = 'com.avairebot'
 description = 'AvaIre Discord Bot'
 mainClassName = 'com.avairebot.Main'

--- a/src/main/java/com/avairebot/GitInfo.java
+++ b/src/main/java/com/avairebot/GitInfo.java
@@ -35,7 +35,7 @@ public class GitInfo extends PropertyConfiguration {
     public final String commitUserEmail;
     public final String commitMessageFull;
     public final String commitMessageShort;
-    public final long commitTime;
+    public final String commitTime;
 
     private GitInfo() {
         loadProperty(getClass().getClassLoader(), "git.properties");
@@ -47,7 +47,7 @@ public class GitInfo extends PropertyConfiguration {
         this.commitUserEmail = String.valueOf(properties.getOrDefault("git.commit.user.email", ""));
         this.commitMessageFull = String.valueOf(properties.getOrDefault("git.commit.message.full", ""));
         this.commitMessageShort = String.valueOf(properties.getOrDefault("git.commit.message.short", ""));
-        this.commitTime = Long.parseLong(String.valueOf(properties.getOrDefault("git.commit.time", "0")));
+        this.commitTime = String.valueOf(properties.getOrDefault("git.commit.time", "Unknown"));
     }
 
     public static GitInfo getGitInfo() {


### PR DESCRIPTION
With the new update of the git gradle plugin, the commit time was changed to a datetime string instead of a UNIX timestamp, this change just prevents throwing an exception when trying to parse the information.